### PR TITLE
Add static attendee portal prototype

### DIFF
--- a/interpolations/portal/contact.html
+++ b/interpolations/portal/contact.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Support</title>
+        <meta
+            name="description"
+            content="Get concierge support for the INTERPOLATIONS conference, from travel planning to accessibility assistance."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell">
+            <header class="portal-nav" role="banner">
+                <a class="portal-brand" href="home.html">
+                    <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                    <span>Interpolations Portal</span>
+                </a>
+                <nav class="portal-nav-links" aria-label="Portal navigation">
+                    <a href="home.html">Home</a>
+                    <a href="profile.html">My details</a>
+                    <a href="tickets.html">My tickets</a>
+                    <a href="contact.html" aria-current="page">Support</a>
+                    <a class="primary-link" href="index.html">Sign out</a>
+                </nav>
+            </header>
+
+            <section class="support-card" aria-labelledby="support-heading">
+                <h1 id="support-heading">Concierge support</h1>
+                <p>
+                    Our team is here for anything you need before, during, and after INTERPOLATIONS. Reach
+                    out and we'll respond within one business day.
+                </p>
+                <div class="support-actions" role="list">
+                    <a href="mailto:concierge@iveseenthefuture.com" role="listitem">
+                        <strong>Email the concierge</strong>
+                        concierge@iveseenthefuture.com
+                    </a>
+                    <a href="tel:+16465550190" role="listitem">
+                        <strong>Call or text</strong>
+                        +1 (646) 555-0190 · 9 AM – 7 PM ET
+                    </a>
+                    <a href="#" role="listitem">
+                        <strong>Live chat</strong>
+                        Message us directly from the portal (beta)
+                    </a>
+                    <a href="https://maps.app.goo.gl/" role="listitem">
+                        <strong>Venue directions</strong>
+                        Spring Studios · 50 Varick St · New York, NY 10013
+                    </a>
+                </div>
+
+                <form class="portal-form" action="#" method="post" aria-labelledby="message-heading">
+                    <h2 id="message-heading" style="margin: 0; font-family: var(--font-display);">
+                        Send us a note
+                    </h2>
+                    <label for="topic">
+                        <span>Topic</span>
+                        <select id="topic" name="topic">
+                            <option>Travel logistics</option>
+                            <option>Accessibility &amp; inclusion</option>
+                            <option>Ticket or billing</option>
+                            <option>Programming question</option>
+                            <option>Something else</option>
+                        </select>
+                    </label>
+                    <label for="message">
+                        <span>How can we help?</span>
+                        <textarea id="message" name="message" placeholder="Share details so we can assist."></textarea>
+                    </label>
+                    <button type="submit">Send message</button>
+                    <p class="form-footnote">
+                        We typically respond within a few hours. For urgent needs call or text the concierge.
+                    </p>
+                </form>
+            </section>
+        </div>
+        <footer class="portal-footer">Looking for FAQs? Visit the <a href="../../index.html#faq">event site</a>.</footer>
+    </body>
+</html>

--- a/interpolations/portal/home.html
+++ b/interpolations/portal/home.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Your Event Hub</title>
+        <meta
+            name="description"
+            content="View your INTERPOLATIONS event ticket, countdown, and resources. Update your attendee profile and explore key event actions."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell">
+            <header class="portal-nav" role="banner">
+                <a class="portal-brand" href="home.html">
+                    <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                    <span>Interpolations Portal</span>
+                </a>
+                <nav class="portal-nav-links" aria-label="Portal navigation">
+                    <a href="home.html" aria-current="page">Home</a>
+                    <a href="profile.html">My details</a>
+                    <a href="tickets.html">My tickets</a>
+                    <a href="contact.html">Support</a>
+                    <a class="primary-link" href="index.html">Sign out</a>
+                </nav>
+            </header>
+
+            <main class="portal-main-card" aria-labelledby="dashboard-title">
+                <div class="portal-intro">
+                    <p class="portal-subheading">Friday · October 24 · New York City</p>
+                    <h1 id="dashboard-title">Welcome back! You're confirmed for INTERPOLATIONS 2025.</h1>
+                    <p>
+                        Doors open at 8:30 AM at Spring Studios in Tribeca. Use this portal to keep your
+                        details current, download your ticket, and find everything you need before showtime.
+                    </p>
+                    <section aria-labelledby="countdown-title">
+                        <h2 id="countdown-title" class="visually-hidden">Event countdown</h2>
+                        <div class="countdown" data-countdown="2025-10-24T09:00:00-04:00">
+                            <div class="time">
+                                <strong data-countdown-days>180</strong>
+                                <span>Days</span>
+                            </div>
+                            <div class="time">
+                                <strong data-countdown-hours>12</strong>
+                                <span>Hours</span>
+                            </div>
+                            <div class="time">
+                                <strong data-countdown-minutes>00</strong>
+                                <span>Minutes</span>
+                            </div>
+                            <div class="time">
+                                <strong data-countdown-seconds>00</strong>
+                                <span>Seconds</span>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+                <aside class="ticket-card" aria-labelledby="ticket-heading">
+                    <header class="ticket-header">
+                        <div>
+                            <p class="portal-subheading">Digital admission</p>
+                            <h2 id="ticket-heading">All-Access Conference Pass</h2>
+                        </div>
+                        <div class="ticket-qr" aria-hidden="true">QR</div>
+                    </header>
+                    <div class="ticket-meta">
+                        <span><strong>Attendee</strong>Jordan Rivera</span>
+                        <span><strong>Email</strong>jordan.rivera@email.com</span>
+                        <span><strong>Check-in opens</strong>08:30 AM ET</span>
+                        <span><strong>Seat zone</strong>Creative Ops</span>
+                    </div>
+                    <p style="margin: 0; position: relative; z-index: 1; color: rgba(16, 30, 45, 0.8);">
+                        Show this ticket on arrival with a photo ID. Tap below to add the pass to your
+                        wallet.
+                    </p>
+                    <a class="portal-button" href="#" role="button">Add to Apple Wallet</a>
+                </aside>
+            </main>
+
+            <section aria-labelledby="quick-actions-heading">
+                <div class="portal-subnav">
+                    <h2 id="quick-actions-heading" style="margin: 0; font-family: var(--font-display);">
+                        Quick actions
+                    </h2>
+                    <span>Stay prepared for the big day.</span>
+                </div>
+                <div class="cta-grid" role="list">
+                    <a class="cta-card" href="profile.html" role="listitem">
+                        <span>Profile</span>
+                        <strong>Update dietary needs &amp; pronouns</strong>
+                        <p>Make sure our team has your latest details and arrival plans.</p>
+                    </a>
+                    <a class="cta-card" href="tickets.html" role="listitem">
+                        <span>Tickets</span>
+                        <strong>Purchase an additional pass</strong>
+                        <p>Bring a teammate or partner with discounted companion pricing.</p>
+                    </a>
+                    <a class="cta-card" href="../../index.html#schedule" role="listitem">
+                        <span>Schedule</span>
+                        <strong>Preview the session lineup</strong>
+                        <p>Bookmark the talks and labs that matter most to your team.</p>
+                    </a>
+                    <a class="cta-card" href="contact.html" role="listitem">
+                        <span>Support</span>
+                        <strong>Chat with the concierge team</strong>
+                        <p>Need travel tips or accessibility support? We're here for you.</p>
+                    </a>
+                </div>
+            </section>
+
+            <section aria-labelledby="info-heading">
+                <div class="portal-subnav">
+                    <h2 id="info-heading" style="margin: 0; font-family: var(--font-display);">
+                        Event essentials
+                    </h2>
+                    <a href="tickets.html">Download confirmation</a>
+                </div>
+                <div class="info-grid">
+                    <article class="info-card" aria-labelledby="arrival-heading">
+                        <h3 id="arrival-heading">Arrival &amp; check-in</h3>
+                        <p>
+                            Please bring a photo ID and arrive between 8:30–9:15 AM for badge pickup. Coffee
+                            and light breakfast will be served.
+                        </p>
+                        <p><strong>Venue:</strong> Spring Studios · 50 Varick St, New York, NY</p>
+                    </article>
+                    <article class="info-card" aria-labelledby="travel-heading">
+                        <h3 id="travel-heading">Travel logistics</h3>
+                        <p>
+                            The closest subway stops are Canal St (A/C/E) and Franklin St (1). Valet parking
+                            is available for $25/day with advance notice.
+                        </p>
+                        <a class="portal-button" href="#">Book ground transportation</a>
+                    </article>
+                    <article class="info-card" aria-labelledby="community-heading">
+                        <h3 id="community-heading">Community updates</h3>
+                        <p>
+                            Join the attendee Slack to meet other creative leaders, share resources, and plan
+                            meetups around the event.
+                        </p>
+                        <a class="portal-button" href="#">Request Slack invite</a>
+                    </article>
+                </div>
+            </section>
+        </div>
+        <footer class="portal-footer">Questions? concierge@iveseenthefuture.com · (646) 555-0190</footer>
+        <script>
+            const countdownEl = document.querySelector('[data-countdown]');
+            if (countdownEl) {
+                const target = new Date(countdownEl.dataset.countdown).getTime();
+                const parts = {
+                    days: countdownEl.querySelector('[data-countdown-days]'),
+                    hours: countdownEl.querySelector('[data-countdown-hours]'),
+                    minutes: countdownEl.querySelector('[data-countdown-minutes]'),
+                    seconds: countdownEl.querySelector('[data-countdown-seconds]'),
+                };
+
+                const tick = () => {
+                    const now = Date.now();
+                    const diff = Math.max(target - now, 0);
+                    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+                    const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+                    const minutes = Math.floor((diff / (1000 * 60)) % 60);
+                    const seconds = Math.floor((diff / 1000) % 60);
+
+                    if (parts.days) parts.days.textContent = String(days);
+                    if (parts.hours) parts.hours.textContent = String(hours).padStart(2, '0');
+                    if (parts.minutes) parts.minutes.textContent = String(minutes).padStart(2, '0');
+                    if (parts.seconds) parts.seconds.textContent = String(seconds).padStart(2, '0');
+
+                    if (diff > 0) {
+                        setTimeout(tick, 1000);
+                    }
+                };
+
+                tick();
+            }
+        </script>
+    </body>
+</html>

--- a/interpolations/portal/index.html
+++ b/interpolations/portal/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Sign In</title>
+        <meta
+            name="description"
+            content="Access your INTERPOLATIONS attendee portal to view tickets, update details, and stay informed about the event."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell" style="gap: var(--space-6);">
+            <a class="portal-brand" href="../../index.html">
+                <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                <span>Interpolations Portal</span>
+            </a>
+            <main class="portal-form-wrapper" aria-labelledby="sign-in-heading">
+                <h1 id="sign-in-heading">Sign in to your attendee portal</h1>
+                <p>
+                    Enter the email you used to register and we'll send a magic link with a one-time
+                    access code. No passwords to remember.
+                </p>
+                <form class="portal-form" action="verify.html" method="get">
+                    <label for="email">
+                        <span>Email address</span>
+                        <input type="email" id="email" name="email" placeholder="you@email.com" required />
+                    </label>
+                    <button type="submit">Email me a sign-in code</button>
+                    <p class="form-footnote">
+                        Already have a code? <a href="verify.html">Enter it here</a> or go back to the
+                        <a href="../../index.html">event website</a>.
+                    </p>
+                </form>
+            </main>
+        </div>
+        <footer class="portal-footer">Made for INTERPOLATIONS attendees — October 24, 2025 · NYC</footer>
+    </body>
+</html>

--- a/interpolations/portal/portal.css
+++ b/interpolations/portal/portal.css
@@ -1,0 +1,600 @@
+:root {
+    --portal-gradient-start: #101e2d;
+    --portal-gradient-end: #172e45;
+    --portal-surface: #ffffff;
+    --portal-surface-subtle: rgba(255, 255, 255, 0.08);
+    --portal-border: rgba(255, 255, 255, 0.12);
+    --portal-card-border: rgba(16, 30, 45, 0.08);
+    --portal-radius: 20px;
+    --portal-radius-sm: 12px;
+    --portal-shadow: 0 25px 60px rgba(16, 30, 45, 0.18);
+    --portal-shadow-soft: 0 18px 40px rgba(16, 30, 45, 0.12);
+    --portal-grid-gap: clamp(16px, 2vw, 32px);
+}
+
+body.portal-body {
+    min-height: 100vh;
+    margin: 0;
+    background: radial-gradient(circle at top right, rgba(242, 90, 127, 0.08), transparent 45%),
+        radial-gradient(circle at bottom left, rgba(242, 90, 127, 0.18), transparent 55%),
+        linear-gradient(145deg, var(--portal-gradient-start), var(--portal-gradient-end));
+    color: var(--bg);
+    font-family: var(--font-ui);
+    display: flex;
+    flex-direction: column;
+}
+
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.portal-shell {
+    width: min(100% - 2 * var(--space-3), 1100px);
+    margin: 0 auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding-block: clamp(var(--space-4), 6vh, var(--space-8));
+}
+
+.portal-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    backdrop-filter: blur(16px);
+    background: rgba(16, 30, 45, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: var(--portal-radius);
+}
+
+.portal-brand {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    text-decoration: none;
+    color: var(--bg);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-size: 0.95rem;
+}
+
+.portal-brand img {
+    height: 36px;
+    width: auto;
+}
+
+.portal-nav-links {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.portal-nav-links a,
+.portal-nav-links button {
+    color: var(--bg);
+    text-decoration: none;
+    padding: 0.55rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-size: 0.95rem;
+    font-weight: 600;
+    background: transparent;
+    transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.portal-nav-links a:hover,
+.portal-nav-links button:hover,
+.portal-nav-links a:focus-visible,
+.portal-nav-links button:focus-visible {
+    border-color: rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.08);
+    outline: none;
+}
+
+.portal-nav-links a[aria-current='page'] {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.25);
+}
+
+.portal-nav-links .primary-link {
+    background: var(--brand);
+    color: #101e2d;
+    border: none;
+}
+
+.portal-nav-links .primary-link:hover,
+.portal-nav-links .primary-link:focus-visible {
+    background: #ff7a99;
+}
+
+.portal-main-card {
+    background: var(--portal-surface);
+    color: var(--ink);
+    border-radius: var(--portal-radius);
+    padding: clamp(var(--space-3), 5vw, var(--space-6));
+    box-shadow: var(--portal-shadow);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(var(--space-3), 5vw, var(--space-6));
+    position: relative;
+    overflow: hidden;
+}
+
+.portal-main-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(242, 90, 127, 0.08), transparent 60%);
+    pointer-events: none;
+}
+
+.portal-intro {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.portal-subheading {
+    margin: 0;
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(16, 30, 45, 0.55);
+    font-weight: 700;
+}
+
+.portal-intro h1 {
+    font-family: var(--font-display);
+    font-size: clamp(2.1rem, 4vw, 3rem);
+    margin: 0;
+}
+
+.portal-intro p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.countdown {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(70px, 1fr));
+    gap: 12px;
+    padding: 12px;
+    border-radius: var(--portal-radius-sm);
+    background: rgba(16, 30, 45, 0.06);
+}
+
+.countdown .time {
+    text-align: center;
+    background: var(--portal-surface);
+    border-radius: var(--portal-radius-sm);
+    padding: 0.85rem;
+    box-shadow: 0 12px 25px rgba(16, 30, 45, 0.12);
+}
+
+.countdown .time strong {
+    display: block;
+    font-size: clamp(1.5rem, 4vw, 2.3rem);
+    font-weight: 700;
+    color: #101e2d;
+}
+
+.countdown .time span {
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.ticket-card {
+    background: linear-gradient(135deg, rgba(242, 90, 127, 0.16), rgba(16, 30, 45, 0.08));
+    border-radius: var(--portal-radius);
+    border: 1px solid var(--portal-card-border);
+    padding: clamp(var(--space-3), 4vw, var(--space-5));
+    display: grid;
+    gap: var(--space-3);
+    position: relative;
+    overflow: hidden;
+}
+
+.ticket-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.25), transparent 55%);
+    mix-blend-mode: screen;
+}
+
+.ticket-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-2);
+    position: relative;
+    z-index: 1;
+}
+
+.ticket-header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    font-family: var(--font-display);
+    letter-spacing: 0.02em;
+}
+
+.ticket-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: var(--space-2);
+    font-size: 0.95rem;
+    position: relative;
+    z-index: 1;
+}
+
+.ticket-meta span {
+    display: flex;
+    flex-direction: column;
+    color: #101e2d;
+    gap: 4px;
+}
+
+.ticket-meta strong {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: rgba(16, 30, 45, 0.7);
+}
+
+.ticket-qr {
+    position: relative;
+    z-index: 1;
+    width: 140px;
+    aspect-ratio: 1 / 1;
+    border-radius: 16px;
+    background: repeating-linear-gradient(45deg, transparent, transparent 6px, rgba(16, 30, 45, 0.2) 6px, rgba(16, 30, 45, 0.2) 12px),
+        linear-gradient(135deg, rgba(16, 30, 45, 0.6), rgba(16, 30, 45, 0.8));
+    display: grid;
+    place-items: center;
+    color: #fff;
+    font-weight: 700;
+    letter-spacing: 0.3em;
+}
+
+.cta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--portal-grid-gap);
+}
+
+.cta-card {
+    background: rgba(16, 30, 45, 0.38);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-sm);
+    padding: clamp(var(--space-3), 4vw, var(--space-4));
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    color: var(--bg);
+    text-decoration: none;
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.cta-card:hover,
+.cta-card:focus-visible {
+    transform: translateY(-4px);
+    background: rgba(16, 30, 45, 0.55);
+    border-color: rgba(255, 255, 255, 0.25);
+    outline: none;
+}
+
+.cta-card span {
+    font-size: 0.85rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.cta-card strong {
+    font-size: 1.1rem;
+    font-family: var(--font-display);
+}
+
+.portal-form-wrapper {
+    margin: 0 auto;
+    width: min(100% - 2 * var(--space-3), 460px);
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--ink);
+    border-radius: var(--portal-radius);
+    padding: clamp(var(--space-3), 5vw, var(--space-5));
+    box-shadow: var(--portal-shadow-soft);
+}
+
+.portal-form-wrapper h1 {
+    font-family: var(--font-display);
+    margin-top: 0;
+    margin-bottom: var(--space-2);
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.portal-form-wrapper p {
+    margin-top: 0;
+    margin-bottom: var(--space-3);
+    color: var(--muted);
+    line-height: 1.6;
+}
+
+.portal-form {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.portal-form label {
+    display: grid;
+    gap: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #101e2d;
+}
+
+.portal-form label span {
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+
+.portal-form input,
+.portal-form select,
+.portal-form textarea,
+.portal-form label input,
+.portal-form label select,
+.portal-form label textarea {
+    border-radius: 12px;
+    border: 1px solid rgba(16, 30, 45, 0.15);
+    padding: 0.85rem 1rem;
+    font: inherit;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.portal-form textarea {
+    min-height: 120px;
+    resize: vertical;
+}
+
+.portal-form input:focus,
+.portal-form select:focus,
+.portal-form textarea:focus {
+    border-color: var(--brand);
+    box-shadow: 0 0 0 3px rgba(242, 90, 127, 0.25);
+    outline: none;
+}
+
+.portal-form button,
+.portal-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: none;
+    border-radius: 999px;
+    padding: 0.9rem 1.6rem;
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: var(--brand);
+    color: #101e2d;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.portal-form button:hover,
+.portal-button:hover,
+.portal-form button:focus-visible,
+.portal-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 30px rgba(242, 90, 127, 0.3);
+    background: #ff7a99;
+    outline: none;
+}
+
+.portal-form .form-footnote {
+    font-size: 0.85rem;
+    color: var(--muted);
+    text-align: center;
+}
+
+.portal-subnav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-2);
+    background: rgba(16, 30, 45, 0.3);
+    border-radius: var(--portal-radius);
+    padding: var(--space-2) var(--space-3);
+    color: var(--bg);
+}
+
+.portal-subnav a {
+    color: var(--bg);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.info-grid {
+    display: grid;
+    gap: var(--portal-grid-gap);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.info-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--portal-radius-sm);
+    padding: clamp(var(--space-3), 4vw, var(--space-4));
+    box-shadow: var(--portal-shadow-soft);
+    color: var(--ink);
+    display: grid;
+    gap: var(--space-2);
+}
+
+.info-card h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    font-family: var(--font-display);
+}
+
+.info-card p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.ticket-list {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.ticket-list-item {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--portal-radius-sm);
+    padding: var(--space-3);
+    border: 1px solid rgba(16, 30, 45, 0.12);
+    display: grid;
+    gap: var(--space-2);
+}
+
+.ticket-list-item header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.ticket-status {
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    background: rgba(16, 30, 45, 0.08);
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: #101e2d;
+}
+
+.ticket-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.ticket-actions .portal-button {
+    background: rgba(16, 30, 45, 0.08);
+    color: #101e2d;
+}
+
+.ticket-actions .portal-button:first-child,
+.ticket-actions .portal-button:nth-child(2) {
+    background: var(--brand);
+    color: #101e2d;
+}
+
+.support-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: var(--portal-radius);
+    padding: clamp(var(--space-3), 5vw, var(--space-6));
+    box-shadow: var(--portal-shadow-soft);
+    color: var(--ink);
+    display: grid;
+    gap: var(--space-3);
+}
+
+.support-card h1 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.support-actions {
+    display: grid;
+    gap: var(--portal-grid-gap);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.support-actions a {
+    display: block;
+    background: rgba(16, 30, 45, 0.08);
+    border-radius: var(--portal-radius-sm);
+    padding: var(--space-3);
+    text-decoration: none;
+    color: inherit;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.support-actions a:hover,
+.support-actions a:focus-visible {
+    background: rgba(242, 90, 127, 0.18);
+    transform: translateY(-2px);
+    outline: none;
+}
+
+.support-actions strong {
+    display: block;
+    margin-bottom: 6px;
+    font-family: var(--font-display);
+}
+
+.portal-footer {
+    margin-top: auto;
+    padding: var(--space-3);
+    text-align: center;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 0.85rem;
+}
+
+.portal-footer a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+    .portal-nav {
+        flex-direction: column;
+        gap: var(--space-2);
+        align-items: flex-start;
+    }
+
+    .portal-nav-links {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .portal-main-card {
+        grid-template-columns: 1fr;
+    }
+
+    .ticket-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .ticket-qr {
+        width: 120px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        transition-duration: 0.001ms !important;
+        animation-duration: 0.001ms !important;
+    }
+}

--- a/interpolations/portal/profile.html
+++ b/interpolations/portal/profile.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Edit Profile</title>
+        <meta
+            name="description"
+            content="Manage your INTERPOLATIONS attendee profile, contact information, and accessibility preferences."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell">
+            <header class="portal-nav" role="banner">
+                <a class="portal-brand" href="home.html">
+                    <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                    <span>Interpolations Portal</span>
+                </a>
+                <nav class="portal-nav-links" aria-label="Portal navigation">
+                    <a href="home.html">Home</a>
+                    <a href="profile.html" aria-current="page">My details</a>
+                    <a href="tickets.html">My tickets</a>
+                    <a href="contact.html">Support</a>
+                    <a class="primary-link" href="index.html">Sign out</a>
+                </nav>
+            </header>
+
+            <section class="support-card" aria-labelledby="profile-heading">
+                <h1 id="profile-heading">Your attendee profile</h1>
+                <p>
+                    Keep these details up to date so we can personalize your experience and provide
+                    thoughtful hospitality.
+                </p>
+                <form class="portal-form" action="#" method="post">
+                    <label for="full-name">
+                        <span>Full name</span>
+                        <input type="text" id="full-name" name="full-name" value="Jordan Rivera" />
+                    </label>
+                    <label for="pronouns">
+                        <span>Pronouns</span>
+                        <select id="pronouns" name="pronouns">
+                            <option>She / Her</option>
+                            <option selected>They / Them</option>
+                            <option>He / Him</option>
+                            <option>Prefer to self-describe</option>
+                        </select>
+                    </label>
+                    <label for="job-title">
+                        <span>Role &amp; organization</span>
+                        <input type="text" id="job-title" name="job-title" value="Director of Creative Ops — Aurora" />
+                    </label>
+                    <label for="mobile">
+                        <span>Mobile number</span>
+                        <input type="tel" id="mobile" name="mobile" value="+1 (917) 555-0112" />
+                    </label>
+                    <label for="dietary">
+                        <span>Dietary notes</span>
+                        <textarea id="dietary" name="dietary">Vegetarian, almond allergy</textarea>
+                    </label>
+                    <label for="accessibility">
+                        <span>Accessibility support</span>
+                        <textarea
+                            id="accessibility"
+                            name="accessibility"
+                            placeholder="Let us know how we can support you."
+                        >Reserved seating for mobility aid, prefer aisle access.</textarea>
+                    </label>
+                    <label for="emergency-contact">
+                        <span>Emergency contact</span>
+                        <input
+                            type="text"
+                            id="emergency-contact"
+                            name="emergency-contact"
+                            value="Miguel Chen — +1 (347) 555-0194"
+                        />
+                    </label>
+                    <button type="submit">Save updates</button>
+                    <p class="form-footnote">
+                        These details sync instantly with the on-site registration team.
+                    </p>
+                </form>
+            </section>
+        </div>
+        <footer class="portal-footer">Last updated 2 minutes ago · Changes auto-save soon</footer>
+    </body>
+</html>

--- a/interpolations/portal/tickets.html
+++ b/interpolations/portal/tickets.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Tickets</title>
+        <meta
+            name="description"
+            content="Review your INTERPOLATIONS tickets, transfer passes, and secure additional seats for your team."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell">
+            <header class="portal-nav" role="banner">
+                <a class="portal-brand" href="home.html">
+                    <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                    <span>Interpolations Portal</span>
+                </a>
+                <nav class="portal-nav-links" aria-label="Portal navigation">
+                    <a href="home.html">Home</a>
+                    <a href="profile.html">My details</a>
+                    <a href="tickets.html" aria-current="page">My tickets</a>
+                    <a href="contact.html">Support</a>
+                    <a class="primary-link" href="index.html">Sign out</a>
+                </nav>
+            </header>
+
+            <section class="support-card" aria-labelledby="tickets-heading">
+                <h1 id="tickets-heading">Your passes &amp; upgrades</h1>
+                <p>
+                    Download your tickets, assign guest seats, or secure extra access for teammates. We'll
+                    email updated confirmations instantly.
+                </p>
+                <div class="ticket-list" role="list">
+                    <article class="ticket-list-item" role="listitem" aria-labelledby="primary-pass">
+                        <header>
+                            <div>
+                                <h2 id="primary-pass" style="margin: 0; font-family: var(--font-display);">
+                                    All-Access Conference Pass
+                                </h2>
+                                <p class="portal-subheading" style="color: rgba(16, 30, 45, 0.6);">
+                                    Primary attendee · Confirmation #A1X9-77
+                                </p>
+                            </div>
+                            <span class="ticket-status">Active</span>
+                        </header>
+                        <p>
+                            Includes general sessions, breakout labs, curated consultations, and closing
+                            reception.
+                        </p>
+                        <div class="ticket-actions">
+                            <a class="portal-button" href="#">Download PDF</a>
+                            <a class="portal-button" href="#">Send to Apple Wallet</a>
+                            <a class="portal-button" href="#">Transfer ticket</a>
+                        </div>
+                    </article>
+                    <article class="ticket-list-item" role="listitem" aria-labelledby="workshop-pass">
+                        <header>
+                            <div>
+                                <h2 id="workshop-pass" style="margin: 0; font-family: var(--font-display);">
+                                    Strategy Lab: AI Roadmaps Workshop
+                                </h2>
+                                <p class="portal-subheading" style="color: rgba(16, 30, 45, 0.6);">
+                                    Optional add-on · Confirmation #B4K2-18
+                                </p>
+                            </div>
+                            <span class="ticket-status" style="background: rgba(242, 90, 127, 0.15); color: #101e2d;">
+                                Waitlisted
+                            </span>
+                        </header>
+                        <p>
+                            We'll notify you if a seat opens up. Upgrade priority goes to early registrants —
+                            check your inbox for updates.
+                        </p>
+                        <a class="portal-button" href="#" style="justify-self: start;">Manage add-ons</a>
+                    </article>
+                </div>
+                <div class="info-grid">
+                    <article class="info-card">
+                        <h3>Need another pass?</h3>
+                        <p>
+                            Secure companion tickets for colleagues or clients at a preferred rate while
+                            inventory lasts.
+                        </p>
+                        <a class="portal-button" href="#">Purchase additional access</a>
+                    </article>
+                    <article class="info-card">
+                        <h3>Travel &amp; hotels</h3>
+                        <p>
+                            Bundle accommodations with your pass to access our partner hotel blocks and
+                            welcome dinner invitations.
+                        </p>
+                        <a class="portal-button" href="#">Explore travel bundles</a>
+                    </article>
+                </div>
+            </section>
+        </div>
+        <footer class="portal-footer">Questions about billing? billing@iveseenthefuture.com</footer>
+    </body>
+</html>

--- a/interpolations/portal/verify.html
+++ b/interpolations/portal/verify.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Verify Code</title>
+        <meta
+            name="description"
+            content="Enter the email sign-in code sent to you to unlock the INTERPOLATIONS attendee portal."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell" style="gap: var(--space-6);">
+            <a class="portal-brand" href="index.html">
+                <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                <span>Interpolations Portal</span>
+            </a>
+            <main class="portal-form-wrapper" aria-labelledby="verify-heading">
+                <h1 id="verify-heading">Check your inbox for the code</h1>
+                <p>
+                    We emailed a one-time six digit code. Enter it below to continue to your personal
+                    event hub.
+                </p>
+                <form class="portal-form" action="home.html" method="get">
+                    <label for="code">
+                        <span>Verification code</span>
+                        <input
+                            type="text"
+                            id="code"
+                            name="code"
+                            pattern="[0-9]{6}"
+                            inputmode="numeric"
+                            autocomplete="one-time-code"
+                            placeholder="123456"
+                            required
+                        />
+                    </label>
+                    <button type="submit">Confirm and continue</button>
+                    <p class="form-footnote">
+                        Haven't seen the email? <a href="index.html">Resend the code</a> or contact
+                        <a href="contact.html">support</a>.
+                    </p>
+                </form>
+            </main>
+        </div>
+        <footer class="portal-footer">Need help? Email concierge@iveseenthefuture.com</footer>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add an attendee portal prototype under `interpolations/portal` with sign-in and verification flows
- create dashboard, profile, tickets, and support views wired together for navigation
- introduce shared portal styling that extends existing brand tokens and includes a live countdown widget

## Testing
- not run (static HTML prototype)


------
https://chatgpt.com/codex/tasks/task_e_68d626555d8083219545261f7dda63b7