### PR TITLE
Simplify attendee portal into single-page hub

### DIFF
--- a/interpolations/portal/home.html
+++ b/interpolations/portal/home.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Event Hub</title>
+        <meta
+            name="description"
+            content="Review your INTERPOLATIONS ticket, countdown, personal details, and key event resources from one streamlined attendee hub."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell">
+            <header class="portal-nav" role="banner">
+                <a class="portal-brand" href="home.html">
+                    <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                    <span>Interpolations Portal</span>
+                </a>
+                <nav class="portal-nav-links" aria-label="Portal navigation">
+                    <a href="#overview">Overview</a>
+                    <a href="#details">Your details</a>
+                    <a href="#actions">Event actions</a>
+                    <a href="#support">Support</a>
+                    <a class="portal-signout" href="index.html">Sign out</a>
+                </nav>
+            </header>
+
+            <main class="portal-main" id="overview">
+                <section class="portal-hero" aria-labelledby="hero-title">
+                    <p class="portal-hero-meta">October 24 · Spring Studios · New York City</p>
+                    <h1 id="hero-title">Welcome back, Jordan.</h1>
+                    <p class="portal-hero-copy">
+                        Everything you need for INTERPOLATIONS 2025 lives here. Check your ticket, confirm your arrival
+                        details, and feel prepared for the big day in just a few taps.
+                    </p>
+                    <div class="portal-hero-links" role="list">
+                        <a class="hero-link" role="listitem" href="#details">Review attendee info</a>
+                        <a class="hero-link" role="listitem" href="#support">Plan your travel</a>
+                    </div>
+                </section>
+
+                <section class="portal-section snapshot" aria-labelledby="snapshot-heading" id="snapshot">
+                    <div class="section-heading">
+                        <h2 id="snapshot-heading">Your event snapshot</h2>
+                        <p>Keep an eye on the countdown and your digital pass.</p>
+                    </div>
+                    <div class="snapshot-grid">
+                        <article class="portal-card countdown-card" aria-labelledby="countdown-title">
+                            <h3 id="countdown-title">Countdown to doors</h3>
+                            <div class="countdown" data-countdown="2025-10-24T09:00:00-04:00">
+                                <div class="time">
+                                    <strong data-countdown-days>180</strong>
+                                    <span>Days</span>
+                                </div>
+                                <div class="time">
+                                    <strong data-countdown-hours>12</strong>
+                                    <span>Hours</span>
+                                </div>
+                                <div class="time">
+                                    <strong data-countdown-minutes>00</strong>
+                                    <span>Minutes</span>
+                                </div>
+                                <div class="time">
+                                    <strong data-countdown-seconds>00</strong>
+                                    <span>Seconds</span>
+                                </div>
+                            </div>
+                            <p class="card-footnote">Doors open at 8:30 AM — arrive by 9:15 AM for keynote seating.</p>
+                        </article>
+                        <article class="portal-card ticket-card" aria-labelledby="ticket-heading">
+                            <div class="ticket-header">
+                                <div>
+                                    <p class="portal-subheading">Digital admission</p>
+                                    <h3 id="ticket-heading">All-Access Conference Pass</h3>
+                                </div>
+                                <div class="ticket-qr" aria-hidden="true">QR</div>
+                            </div>
+                            <dl class="ticket-meta">
+                                <div>
+                                    <dt>Attendee</dt>
+                                    <dd>Jordan Rivera</dd>
+                                </div>
+                                <div>
+                                    <dt>Email</dt>
+                                    <dd>jordan.rivera@email.com</dd>
+                                </div>
+                                <div>
+                                    <dt>Seat zone</dt>
+                                    <dd>Creative Ops</dd>
+                                </div>
+                                <div>
+                                    <dt>Check-in</dt>
+                                    <dd>Opens 08:30 AM ET</dd>
+                                </div>
+                            </dl>
+                            <a class="ticket-action" href="#">Add to wallet</a>
+                        </article>
+                        <article class="portal-card arrival-card" aria-labelledby="arrival-heading">
+                            <h3 id="arrival-heading">Day-of briefing</h3>
+                            <ul>
+                                <li>Badge pickup on level 5 — elevators to the right of the lobby.</li>
+                                <li>Breakfast and coffee available from 8:30–10:00 AM.</li>
+                                <li>Opening keynote begins promptly at 9:30 AM in Studio B.</li>
+                            </ul>
+                            <a class="inline-link" href="../../index.html#schedule">Preview full schedule</a>
+                        </article>
+                    </div>
+                </section>
+
+                <section class="portal-section details" aria-labelledby="details-heading" id="details">
+                    <div class="section-heading">
+                        <h2 id="details-heading">Your details</h2>
+                        <p>Update preferences so our team can personalize your experience.</p>
+                    </div>
+                    <form class="details-form" action="#" method="post">
+                        <div class="form-grid">
+                            <label for="name">
+                                <span>Full name</span>
+                                <input type="text" id="name" name="name" value="Jordan Rivera" />
+                            </label>
+                            <label for="email">
+                                <span>Email</span>
+                                <input type="email" id="email" name="email" value="jordan.rivera@email.com" readonly />
+                            </label>
+                            <label for="pronouns">
+                                <span>Pronouns</span>
+                                <input type="text" id="pronouns" name="pronouns" placeholder="she/her, he/him, they/them" />
+                            </label>
+                            <label for="dietary">
+                                <span>Dietary notes</span>
+                                <input type="text" id="dietary" name="dietary" placeholder="Vegan, gluten-free, etc." />
+                            </label>
+                            <label for="phone">
+                                <span>Mobile number</span>
+                                <input type="tel" id="phone" name="phone" placeholder="(646) 555-0190" />
+                            </label>
+                            <label for="arrival">
+                                <span>Arrival window</span>
+                                <select id="arrival" name="arrival">
+                                    <option value="">Select an option</option>
+                                    <option value="early">08:30 – 09:00 AM</option>
+                                    <option value="standard">09:00 – 09:30 AM</option>
+                                    <option value="late">After 09:30 AM</option>
+                                </select>
+                            </label>
+                        </div>
+                        <div class="form-actions">
+                            <button type="submit">Save changes</button>
+                            <p>We'll email a confirmation if anything looks unusual.</p>
+                        </div>
+                    </form>
+                </section>
+
+                <section class="portal-section actions" aria-labelledby="actions-heading" id="actions">
+                    <div class="section-heading">
+                        <h2 id="actions-heading">Event actions</h2>
+                        <p>Small but mighty shortcuts for popular tasks.</p>
+                    </div>
+                    <div class="action-grid" role="list">
+                        <a class="action-chip" role="listitem" href="../../index.html#tickets">Buy another ticket</a>
+                        <a class="action-chip" role="listitem" href="../../index.html#speakers">Meet the speakers</a>
+                        <a class="action-chip" role="listitem" href="#support">Contact concierge</a>
+                        <a class="action-chip" role="listitem" href="../../index.html#faq">View FAQ</a>
+                    </div>
+                </section>
+
+                <section class="portal-section support" aria-labelledby="support-heading" id="support">
+                    <div class="section-heading">
+                        <h2 id="support-heading">Support & logistics</h2>
+                        <p>Plan your trip and know who to reach before and during the event.</p>
+                    </div>
+                    <div class="support-grid">
+                        <article class="portal-card" aria-labelledby="venue-heading">
+                            <h3 id="venue-heading">Venue</h3>
+                            <p>Spring Studios · 50 Varick Street · New York, NY 10013</p>
+                            <p>Closest subway stops: Canal St (A/C/E) and Franklin St (1).</p>
+                            <a class="inline-link" href="https://maps.app.goo.gl/">Open in Maps</a>
+                        </article>
+                        <article class="portal-card" aria-labelledby="travel-heading">
+                            <h3 id="travel-heading">Travel help</h3>
+                            <p>Need hotel suggestions or accessibility accommodations? Our concierge team is on call.</p>
+                            <ul>
+                                <li>Email <a class="inline-link" href="mailto:concierge@iveseenthefuture.com">concierge@iveseenthefuture.com</a></li>
+                                <li>Text <a class="inline-link" href="tel:+16465550190">(646) 555-0190</a></li>
+                            </ul>
+                        </article>
+                        <article class="portal-card" aria-labelledby="community-heading">
+                            <h3 id="community-heading">Community</h3>
+                            <p>Join the attendee Slack to coordinate meetups and swap travel tips.</p>
+                            <a class="inline-link" href="#">Request Slack invite</a>
+                        </article>
+                    </div>
+                </section>
+            </main>
+        </div>
+        <footer class="portal-footer">Interpolations 2025 · Questions? concierge@iveseenthefuture.com</footer>
+        <script>
+            const countdownEl = document.querySelector('[data-countdown]');
+            if (countdownEl) {
+                const target = new Date(countdownEl.dataset.countdown).getTime();
+                const parts = {
+                    days: countdownEl.querySelector('[data-countdown-days]'),
+                    hours: countdownEl.querySelector('[data-countdown-hours]'),
+                    minutes: countdownEl.querySelector('[data-countdown-minutes]'),
+                    seconds: countdownEl.querySelector('[data-countdown-seconds]'),
+                };
+
+                const tick = () => {
+                    const now = Date.now();
+                    const diff = Math.max(target - now, 0);
+                    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+                    const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+                    const minutes = Math.floor((diff / (1000 * 60)) % 60);
+                    const seconds = Math.floor((diff / 1000) % 60);
+
+                    if (parts.days) parts.days.textContent = String(days);
+                    if (parts.hours) parts.hours.textContent = String(hours).padStart(2, '0');
+                    if (parts.minutes) parts.minutes.textContent = String(minutes).padStart(2, '0');
+                    if (parts.seconds) parts.seconds.textContent = String(seconds).padStart(2, '0');
+
+                    if (diff > 0) {
+                        setTimeout(tick, 1000);
+                    }
+                };
+
+                tick();
+            }
+        </script>
+    </body>
+</html>

--- a/interpolations/portal/index.html
+++ b/interpolations/portal/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Sign In</title>
+        <meta
+            name="description"
+            content="Access your INTERPOLATIONS attendee portal to view tickets, update details, and stay informed about the event."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell" style="gap: var(--space-6);">
+            <a class="portal-brand" href="../../index.html">
+                <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                <span>Interpolations Portal</span>
+            </a>
+            <main class="portal-form-wrapper" aria-labelledby="sign-in-heading">
+                <h1 id="sign-in-heading">Sign in to your attendee portal</h1>
+                <p>
+                    Enter the email you used to register and we'll send a magic link with a one-time
+                    access code. No passwords to remember.
+                </p>
+                <form class="portal-form" action="verify.html" method="get">
+                    <label for="email">
+                        <span>Email address</span>
+                        <input type="email" id="email" name="email" placeholder="you@email.com" required />
+                    </label>
+                    <button type="submit">Email me a sign-in code</button>
+                    <p class="form-footnote">
+                        Already have a code? <a href="verify.html">Enter it here</a> or go back to the
+                        <a href="../../index.html">event website</a>.
+                    </p>
+                </form>
+            </main>
+        </div>
+        <footer class="portal-footer">Made for INTERPOLATIONS attendees — October 24, 2025 · NYC</footer>
+    </body>
+</html>

--- a/interpolations/portal/portal.css
+++ b/interpolations/portal/portal.css
@@ -1,0 +1,579 @@
+:root {
+    --portal-bg-start: #101e2d;
+    --portal-bg-end: #1b3752;
+    --portal-surface: #ffffff;
+    --portal-surface-tinted: rgba(255, 255, 255, 0.08);
+    --portal-card-shadow: 0 20px 40px rgba(9, 19, 30, 0.18);
+    --portal-radius-lg: 20px;
+    --portal-radius: 14px;
+    --portal-radius-sm: 10px;
+    --portal-max-width: 1080px;
+}
+
+body.portal-body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: var(--font-ui);
+    background: linear-gradient(150deg, var(--portal-bg-start), var(--portal-bg-end));
+    color: var(--bg);
+    display: flex;
+    flex-direction: column;
+}
+
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.portal-shell {
+    width: min(100% - 2 * var(--space-3), var(--portal-max-width));
+    margin: 0 auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding-block: clamp(var(--space-4), 7vh, var(--space-8));
+}
+
+.portal-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: var(--portal-radius-lg);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    padding: var(--space-2) var(--space-3);
+    background: rgba(16, 30, 45, 0.45);
+    backdrop-filter: blur(16px);
+}
+
+.portal-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    text-decoration: none;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--bg);
+    font-size: 0.95rem;
+}
+
+.portal-brand img {
+    width: 34px;
+    height: 34px;
+}
+
+.portal-nav-links {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.portal-nav-links a {
+    color: var(--bg);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 0.45rem 1rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.portal-nav-links a:hover,
+.portal-nav-links a:focus-visible {
+    border-color: rgba(255, 255, 255, 0.32);
+    background: rgba(255, 255, 255, 0.12);
+    outline: none;
+}
+
+.portal-nav-links a[href^='#'] {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.portal-signout {
+    background: var(--brand);
+    color: #102032;
+    border: none !important;
+}
+
+.portal-signout:hover,
+.portal-signout:focus-visible {
+    background: #ff7a99;
+}
+
+.portal-main {
+    background: var(--portal-surface);
+    color: var(--ink);
+    border-radius: var(--portal-radius-lg);
+    box-shadow: var(--portal-card-shadow);
+    padding: clamp(var(--space-4), 6vw, var(--space-7));
+    display: flex;
+    flex-direction: column;
+    gap: clamp(var(--space-4), 4vw, var(--space-6));
+}
+
+.portal-hero {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.portal-hero-meta {
+    margin: 0;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(16, 30, 45, 0.55);
+    font-weight: 700;
+}
+
+.portal-hero h1 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(2.1rem, 5vw, 3.1rem);
+}
+
+.portal-hero-copy {
+    margin: 0;
+    color: var(--muted);
+    font-size: 1.05rem;
+    max-width: 55ch;
+}
+
+.portal-hero-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.hero-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: rgba(16, 30, 45, 0.07);
+    color: var(--ink);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.hero-link::after {
+    content: '→';
+    font-size: 0.9em;
+}
+
+.hero-link:hover,
+.hero-link:focus-visible {
+    background: rgba(16, 30, 45, 0.12);
+    outline: none;
+}
+
+.portal-section {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.section-heading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.section-heading h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.6rem, 3vw, 2.1rem);
+}
+
+.section-heading p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.snapshot-grid,
+.support-grid {
+    display: grid;
+    gap: clamp(var(--space-3), 4vw, var(--space-4));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.portal-card {
+    background: linear-gradient(160deg, #fff 0%, #f9fbff 100%);
+    border-radius: var(--portal-radius);
+    padding: clamp(var(--space-3), 4vw, var(--space-4));
+    box-shadow: 0 18px 38px rgba(16, 30, 45, 0.12);
+    display: grid;
+    gap: var(--space-2);
+}
+
+.portal-card h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.countdown-card {
+    background: radial-gradient(circle at top right, rgba(242, 90, 127, 0.14), transparent 65%),
+        linear-gradient(160deg, #fff, #f8f0f3);
+}
+
+.countdown {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(64px, 1fr));
+    gap: 10px;
+}
+
+.countdown .time {
+    background: var(--portal-surface);
+    border-radius: var(--portal-radius-sm);
+    text-align: center;
+    padding: 0.75rem 0.4rem;
+    box-shadow: 0 12px 24px rgba(16, 30, 45, 0.12);
+}
+
+.countdown .time strong {
+    display: block;
+    font-size: clamp(1.45rem, 4vw, 2.1rem);
+    color: #102032;
+}
+
+.countdown .time span {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(16, 30, 45, 0.55);
+}
+
+.card-footnote {
+    margin: 0;
+    color: rgba(16, 30, 45, 0.6);
+    font-size: 0.85rem;
+}
+
+.ticket-card {
+    position: relative;
+    overflow: hidden;
+}
+
+.ticket-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(242, 90, 127, 0.08), transparent 65%);
+    pointer-events: none;
+}
+
+.ticket-card > * {
+    position: relative;
+    z-index: 1;
+}
+
+.ticket-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-3);
+}
+
+.portal-subheading {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.75rem;
+    color: rgba(16, 30, 45, 0.55);
+    font-weight: 700;
+}
+
+.ticket-header h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.ticket-qr {
+    width: 64px;
+    height: 64px;
+    border-radius: 12px;
+    background: rgba(16, 30, 45, 0.12);
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 0.8rem;
+    letter-spacing: 0.18em;
+    color: rgba(16, 30, 45, 0.6);
+}
+
+.ticket-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--space-2);
+    margin: 0;
+}
+
+.ticket-meta div {
+    display: grid;
+    gap: 0.2rem;
+}
+
+.ticket-meta dt {
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(16, 30, 45, 0.55);
+    margin: 0;
+}
+
+.ticket-meta dd {
+    margin: 0;
+    font-weight: 600;
+    color: #102032;
+}
+
+.ticket-action {
+    justify-self: start;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    background: #102032;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.ticket-action:hover,
+.ticket-action:focus-visible {
+    background: #1a3b5a;
+    outline: none;
+}
+
+.arrival-card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.45rem;
+    color: rgba(16, 30, 45, 0.78);
+    font-size: 0.95rem;
+}
+
+.inline-link {
+    color: #1a3b5a;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.inline-link:hover,
+.inline-link:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+.details-form {
+    background: linear-gradient(160deg, #f9fbff, #fff);
+    border-radius: var(--portal-radius);
+    padding: clamp(var(--space-3), 4vw, var(--space-4));
+    box-shadow: 0 12px 32px rgba(16, 30, 45, 0.12);
+    display: grid;
+    gap: var(--space-3);
+}
+
+.form-grid {
+    display: grid;
+    gap: var(--space-3);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.details-form label {
+    display: grid;
+    gap: 0.55rem;
+    font-weight: 600;
+    color: #102032;
+}
+
+.details-form input,
+.details-form select {
+    border-radius: 12px;
+    border: 1px solid rgba(16, 30, 45, 0.16);
+    padding: 0.7rem 0.9rem;
+    font: inherit;
+    color: inherit;
+    background: #fff;
+}
+
+.details-form input:focus-visible,
+.details-form select:focus-visible {
+    outline: 2px solid rgba(242, 90, 127, 0.45);
+    border-color: rgba(242, 90, 127, 0.45);
+}
+
+.details-form input[readonly] {
+    background: rgba(16, 30, 45, 0.06);
+    color: rgba(16, 30, 45, 0.6);
+}
+
+.form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    color: rgba(16, 30, 45, 0.6);
+    font-size: 0.9rem;
+}
+
+.form-actions button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.6rem 1.4rem;
+    background: var(--brand);
+    color: #102032;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.form-actions button:hover,
+.form-actions button:focus-visible {
+    background: #ff7a99;
+    outline: none;
+}
+
+.action-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.action-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.95rem;
+    border-radius: 999px;
+    background: rgba(16, 30, 45, 0.08);
+    color: #102032;
+    font-weight: 600;
+    font-size: 0.88rem;
+    text-decoration: none;
+}
+
+.action-chip::after {
+    content: '↗';
+    font-size: 0.85em;
+}
+
+.action-chip:hover,
+.action-chip:focus-visible {
+    background: rgba(16, 30, 45, 0.14);
+    outline: none;
+}
+
+.support-grid article ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.35rem;
+    color: rgba(16, 30, 45, 0.7);
+}
+
+.portal-footer {
+    margin-top: var(--space-4);
+    padding: var(--space-3);
+    text-align: center;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.85rem;
+}
+
+/* Forms used by login + verification */
+.portal-form-wrapper {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--portal-radius-lg);
+    padding: clamp(var(--space-4), 5vw, var(--space-6));
+    display: grid;
+    gap: var(--space-3);
+    color: var(--bg);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.portal-form-wrapper h1 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.9rem, 4vw, 2.6rem);
+}
+
+.portal-form-wrapper p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.portal-form {
+    display: grid;
+    gap: var(--space-3);
+}
+
+.portal-form label {
+    display: grid;
+    gap: 0.6rem;
+    font-weight: 600;
+}
+
+.portal-form input {
+    border-radius: 12px;
+    border: none;
+    padding: 0.75rem 1rem;
+    font: inherit;
+}
+
+.portal-form button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.7rem 1.6rem;
+    background: var(--brand);
+    color: #102032;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.portal-form button:hover,
+.portal-form button:focus-visible {
+    background: #ff7a99;
+    outline: none;
+}
+
+.form-footnote {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.form-footnote a {
+    color: inherit;
+}
+
+.form-footnote a:hover,
+.form-footnote a:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+@media (max-width: 720px) {
+    .portal-nav {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-3);
+    }
+
+    .portal-nav-links {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .countdown {
+        grid-template-columns: repeat(2, minmax(64px, 1fr));
+    }
+}

--- a/interpolations/portal/verify.html
+++ b/interpolations/portal/verify.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>INTERPOLATIONS Portal — Verify Code</title>
+        <meta
+            name="description"
+            content="Enter the email sign-in code sent to you to unlock the INTERPOLATIONS attendee portal."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700;800&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="../../auto-style.css" />
+        <link rel="stylesheet" href="portal.css" />
+    </head>
+    <body class="portal-body">
+        <div class="portal-shell" style="gap: var(--space-6);">
+            <a class="portal-brand" href="index.html">
+                <img src="../../assets/interpolations-icon-portal-sorbet.png" alt="Interpolations icon" />
+                <span>Interpolations Portal</span>
+            </a>
+            <main class="portal-form-wrapper" aria-labelledby="verify-heading">
+                <h1 id="verify-heading">Check your inbox for the code</h1>
+                <p>
+                    We emailed a one-time six digit code. Enter it below to continue to your personal
+                    event hub.
+                </p>
+                <form class="portal-form" action="home.html" method="get">
+                    <label for="code">
+                        <span>Verification code</span>
+                        <input
+                            type="text"
+                            id="code"
+                            name="code"
+                            pattern="[0-9]{6}"
+                            inputmode="numeric"
+                            autocomplete="one-time-code"
+                            placeholder="123456"
+                            required
+                        />
+                    </label>
+                    <button type="submit">Confirm and continue</button>
+                    <p class="form-footnote">
+                        Haven't seen the email? <a href="index.html">Resend the code</a> or visit the
+                        <a href="home.html#support">support section</a> for help.
+                    </p>
+                </form>
+            </main>
+        </div>
+        <footer class="portal-footer">Need help? Email concierge@iveseenthefuture.com</footer>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- consolidate the attendee experience into a single portal page with section anchors for navigation
- redesign the hero, countdown, ticket view, and support content to feel lighter while keeping key info in one place
- add an inline attendee details form and smaller action chips for common tasks, removing the redundant sub-pages

## Testing
- not run (static HTML prototype)

------
https://chatgpt.com/codex/tasks/task_e_68d626555d8083219545261f7dda63b7