### PR TITLE
Add blog index listing and dedicated post page

### DIFF
--- a/blog/blog.css
+++ b/blog/blog.css
@@ -1,0 +1,380 @@
+:root {
+    --font-display: "Fraunces", serif;
+    --font-ui: "Manrope", system-ui, sans-serif;
+    --ink: #0a0a0a;
+    --ink-muted: #4b5563;
+    --bg: #f8fafc;
+    --bg-card: #ffffff;
+    --brand: #f25a7f;
+    --brand-dark: #c94363;
+    --border: rgba(15, 23, 42, 0.1);
+    --shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+    --container: 1100px;
+    --gutter: clamp(20px, 4vw, 48px);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--font-ui);
+    background: var(--bg);
+    color: var(--ink);
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+}
+
+img,
+svg {
+    max-width: 100%;
+    display: block;
+}
+
+a {
+    color: var(--brand);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.container {
+    width: min(100% - 2 * var(--gutter), var(--container));
+    margin-inline: auto;
+}
+
+.blog-hero {
+    position: relative;
+    background: radial-gradient(circle at 20% 20%, rgba(242, 90, 127, 0.35), transparent 60%),
+        radial-gradient(circle at 80% 30%, rgba(77, 104, 255, 0.25), transparent 65%),
+        linear-gradient(140deg, #0f172a, #111827 55%, #1f2937);
+    color: #f8fafc;
+    padding: clamp(4rem, 8vw, 8rem) 0;
+    overflow: hidden;
+}
+
+.blog-hero--index {
+    background: radial-gradient(circle at 15% 25%, rgba(242, 90, 127, 0.28), transparent 55%),
+        radial-gradient(circle at 75% 20%, rgba(77, 104, 255, 0.22), transparent 60%),
+        linear-gradient(150deg, #111827, #1e293b 55%, #312e81);
+}
+
+.blog-hero--article .hero-content {
+    gap: clamp(0.75rem, 3vw, 1.5rem);
+}
+
+.hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.2));
+    pointer-events: none;
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 700;
+    opacity: 0.85;
+}
+
+.eyebrow::before {
+    content: "";
+    width: 40px;
+    height: 1.5px;
+    background: currentColor;
+    opacity: 0.6;
+}
+
+h1 {
+    font-family: var(--font-display);
+    font-size: clamp(2.5rem, 6vw, 3.6rem);
+    line-height: 1.05;
+    margin: 0;
+}
+
+.hero-dek {
+    max-width: 52ch;
+    font-size: clamp(1.05rem, 2.5vw, 1.35rem);
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.meta {
+    font-size: 0.95rem;
+    color: rgba(248, 250, 252, 0.7);
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: rgba(248, 250, 252, 0.8);
+    font-weight: 600;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.back-link:hover,
+.back-link:focus {
+    color: #fff;
+    text-decoration: underline;
+}
+
+.blog-article {
+    margin-top: clamp(3rem, 8vw, 5rem);
+    margin-bottom: clamp(4rem, 10vw, 6rem);
+    padding: clamp(2.5rem, 6vw, 4rem);
+    background: var(--bg-card);
+    border-radius: 24px;
+    box-shadow: var(--shadow);
+}
+
+.blog-article > * + * {
+    margin-top: 1.6em;
+}
+
+.blog-article h2 {
+    font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    margin-bottom: 0.4em;
+    color: #0f172a;
+}
+
+.blog-article p {
+    font-size: clamp(1rem, 2.2vw, 1.1rem);
+    color: var(--ink);
+    margin: 0;
+}
+
+.blog-article ul {
+    padding-left: 1.2rem;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+    font-size: clamp(1rem, 2.2vw, 1.1rem);
+}
+
+.blog-article li {
+    background: linear-gradient(120deg, rgba(242, 90, 127, 0.08), rgba(242, 90, 127, 0));
+    padding: 1rem 1.25rem;
+    border-radius: 16px;
+    border: 1px solid rgba(242, 90, 127, 0.15);
+}
+
+.blog-article strong {
+    font-weight: 700;
+}
+
+blockquote {
+    margin: 2rem 0;
+    padding: 1.5rem 2rem;
+    border-left: 4px solid var(--brand);
+    background: linear-gradient(135deg, rgba(242, 90, 127, 0.12), rgba(242, 90, 127, 0.02));
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: clamp(1.2rem, 3vw, 1.45rem);
+    color: #111827;
+}
+
+.callout {
+    margin-top: clamp(3rem, 8vw, 4rem);
+    padding: clamp(2rem, 5vw, 3rem);
+    border-radius: 20px;
+    border: 1px solid var(--border);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.8));
+    box-shadow: 0 24px 60px rgba(148, 163, 184, 0.25);
+}
+
+.callout h3 {
+    margin: 0 0 1rem;
+    font-family: var(--font-display);
+    font-size: clamp(1.4rem, 3vw, 1.8rem);
+}
+
+.newsletter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+}
+
+.newsletter input {
+    flex: 1 1 220px;
+    padding: 0.85rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.15);
+    font-size: 1rem;
+    font-family: var(--font-ui);
+}
+
+.newsletter button {
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--brand);
+    color: #fff;
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.newsletter button:hover,
+.newsletter button:focus {
+    background: var(--brand-dark);
+}
+
+.newsletter-disclaimer {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: var(--ink-muted);
+}
+
+.post-grid {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2rem);
+    margin: clamp(3rem, 8vw, 5rem) 0 clamp(5rem, 10vw, 6rem);
+}
+
+.post-card {
+    background: var(--bg-card);
+    border-radius: 24px;
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.post-card__link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    color: inherit;
+}
+
+.post-card__body {
+    padding: clamp(2rem, 5vw, 2.75rem);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.post-card__eyebrow {
+    font-size: 0.85rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--brand);
+    margin: 0;
+}
+
+.post-card__title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.75rem, 4vw, 2.2rem);
+    color: #0f172a;
+}
+
+.post-card__excerpt {
+    margin: 0;
+    font-size: clamp(1rem, 2.2vw, 1.1rem);
+    color: var(--ink);
+}
+
+.post-card__meta {
+    margin: 0;
+    padding: 1.25rem clamp(2rem, 5vw, 2.75rem);
+    display: flex;
+    gap: 1.5rem;
+    font-size: 0.95rem;
+    color: var(--ink-muted);
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.post-card:hover,
+.post-card:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 28px 65px rgba(15, 23, 42, 0.18);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.blog-footer {
+    padding: clamp(3rem, 6vw, 4rem) 0 clamp(2rem, 5vw, 3rem);
+    background: #0f172a;
+    color: rgba(226, 232, 240, 0.92);
+}
+
+.footer-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.footer-title {
+    font-family: var(--font-display);
+    font-size: 1.3rem;
+    margin: 0;
+}
+
+.footer-copy,
+.footer-meta {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.8);
+}
+
+@media (max-width: 768px) {
+    .blog-article {
+        padding: clamp(1.75rem, 8vw, 2.5rem);
+        border-radius: 18px;
+    }
+
+    .blog-article ul {
+        gap: 0.75rem;
+    }
+
+    blockquote {
+        margin-inline: -1rem;
+        border-radius: 0 20px 20px 0;
+    }
+
+    .post-card__body {
+        padding: clamp(1.5rem, 6vw, 2rem);
+    }
+
+    .post-card__meta {
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: clamp(1.25rem, 7vw, 1.75rem) clamp(1.5rem, 6vw, 2rem);
+    }
+}

--- a/blog/exploring-creative-possibilities.html
+++ b/blog/exploring-creative-possibilities.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Exploring Creative Possibilities with Interpolations</title>
+        <meta
+            name="description"
+            content="How the Interpolations community, directory, and conference help creative professionals experiment with emerging AI tools."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="blog.css" />
+    </head>
+    <body class="blog-post">
+        <header class="blog-hero blog-hero--article">
+            <div class="hero-overlay"></div>
+            <div class="container hero-content">
+                <a class="back-link" href="index.html">← Back to all posts</a>
+                <p class="eyebrow">Interpolations Journal</p>
+                <h1>Exploring Creative Possibilities with Interpolations</h1>
+                <p class="hero-dek">
+                    How a new community, directory, and conference are helping creative professionals navigate emerging AI tools.
+                </p>
+                <p class="meta">Published October 24, 2025 · 6 minute read</p>
+            </div>
+        </header>
+        <main class="container">
+            <article class="blog-article">
+                <p>
+                    The creative world feels like it’s at an inflection point when it comes to nearly every facet of our work. From the tools we use to the value we bring inside companies, everything is in flux more than usual—and the pace isn’t slowing down.
+                </p>
+                <p>
+                    While there’s an infinite number of topics to investigate, we’re channeling that curiosity into a dedicated home for the conversations that matter most right now. Interpolations is a new community and conference for creative professionals interested in being part of the dialogue around emerging AI tools.
+                </p>
+                <p>
+                    Our community will explore and share experiences, case studies, and tangible workflows that help you navigate these changing times with confidence. Think of this space as a living lab where designers, strategists, producers, and technologists compare notes on what’s working—and what still needs work.
+                </p>
+
+                <h2>Why Now</h2>
+                <p>
+                    These new tools are exciting and imperfect. They’re evolving and transforming every day. It feels like a pivotal moment to both experiment and establish a point of view about how AI fits into your creative workflow.
+                </p>
+                <blockquote>
+                    "Now is the time to acquire and harness these tools—before the playbooks are set and the next wave of innovation arrives."
+                </blockquote>
+
+                <p>
+                    Interpolations will share the lessons that come from real-world experimentation so that teams can move faster than the hype cycle. We’re especially focused on bridging the gap between inspiration and implementation.
+                </p>
+
+                <h2>Resources We&rsquo;re Building</h2>
+                <p>
+                    To help the creative community level up together, we’re investing in resources that provide immediate value:
+                </p>
+                <ul>
+                    <li>
+                        <strong>AI Tools Directory:</strong> A growing, curated list of the most useful tools we’ve encountered. Browse by use case or workflow and discover the best fits for your team.
+                    </li>
+                    <li>
+                        <strong>Field Notes &amp; Playbooks:</strong> Honest write-ups on what happens when creative teams put AI tools into production.
+                    </li>
+                    <li>
+                        <strong>Community Spotlights:</strong> Profiles of designers, agencies, and studios experimenting in public and sharing back what they learn.
+                    </li>
+                </ul>
+                <p>
+                    The AI tools directory is fairly simple today, but it’s growing quickly. If you need to find an AI tool for a specific use case—or you’re looking for general recommendations—this directory is for you. We’ll keep adding more content, details, and tools. Have a favorite we should include? <a href="mailto:hello@iveseenthefuture.com">Send a recommendation</a> and we’ll dig in.
+                </p>
+
+                <h2>Join Us in New York City</h2>
+                <p>
+                    Our first in-person event is a design conference in New York City on October 24th. We’re gathering leading designers, creative directors, agencies, and in-house teams to discuss and share how they’re using AI tools in their work.
+                </p>
+                <p>
+                    Expect thoughtful talks, hands-on workshops, and plenty of time to trade ideas with peers who are figuring out the same questions you are. Tickets are limited so we can keep conversations intimate and actionable.
+                </p>
+
+                <section class="callout">
+                    <h3>Stay in the Loop</h3>
+                    <p>
+                        To stay up to date on all things Interpolations, subscribe to our newsletter. We’ll share new resources, event announcements, and community stories as soon as they’re ready.
+                    </p>
+                    <form class="newsletter" action="#" method="post">
+                        <label class="sr-only" for="email">Email address</label>
+                        <input type="email" id="email" name="email" placeholder="you@example.com" required />
+                        <button type="submit">Notify Me</button>
+                    </form>
+                    <p class="newsletter-disclaimer">We respect your inbox—no spam, just thoughtful updates.</p>
+                </section>
+
+                <p>
+                    This is just the beginning. Over the coming weeks, the blog will feature interviews, process breakdowns, and resources to help you chart your path through this new landscape. We’re glad you’re here and can’t wait to see what you make.
+                </p>
+            </article>
+        </main>
+        <footer class="blog-footer">
+            <div class="container footer-content">
+                <p class="footer-title">Interpolations</p>
+                <p class="footer-copy">Design &amp; AI conversations for curious creative teams.</p>
+                <p class="footer-meta">© <span id="year"></span> Interpolations. All rights reserved.</p>
+            </div>
+        </footer>
+        <script>
+            document.getElementById("year").textContent = new Date().getFullYear();
+        </script>
+    </body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Interpolations Blog — Ideas for Creative Teams</title>
+        <meta
+            name="description"
+            content="The Interpolations blog shares ideas, tools, and events for creative teams experimenting with AI."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=Manrope:wght@400;500;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="blog.css" />
+    </head>
+    <body class="blog-index">
+        <header class="blog-hero blog-hero--index">
+            <div class="hero-overlay"></div>
+            <div class="container hero-content">
+                <p class="eyebrow">Interpolations Journal</p>
+                <h1>Fresh perspectives on creative work &amp; AI tools</h1>
+                <p class="hero-dek">
+                    Follow along as we document experiments, share resources, and highlight the community shaping the future of creative practice.
+                </p>
+            </div>
+        </header>
+        <main class="container">
+            <section class="post-grid" aria-label="Blog posts">
+                <article class="post-card">
+                    <a class="post-card__link" href="exploring-creative-possibilities.html">
+                        <div class="post-card__body">
+                            <p class="post-card__eyebrow">Field Notes</p>
+                            <h2 class="post-card__title">Exploring Creative Possibilities with Interpolations</h2>
+                            <p class="post-card__excerpt">
+                                How a new community, directory, and conference are helping creative professionals navigate emerging AI tools.
+                            </p>
+                        </div>
+                        <footer class="post-card__meta">
+                            <span>October 24, 2025</span>
+                            <span>6 min read</span>
+                        </footer>
+                    </a>
+                </article>
+            </section>
+        </main>
+        <footer class="blog-footer">
+            <div class="container footer-content">
+                <p class="footer-title">Interpolations</p>
+                <p class="footer-copy">Design &amp; AI conversations for curious creative teams.</p>
+                <p class="footer-meta">© <span id="year"></span> Interpolations. All rights reserved.</p>
+            </div>
+        </footer>
+        <script>
+            document.getElementById("year").textContent = new Date().getFullYear();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- create a `/blog/` index view that introduces the journal and lists available posts
- move the existing article into its own `/blog/exploring-creative-possibilities.html` page with a back link
- extend shared blog styles to support the index cards and navigation affordances

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68daf5cc46fc8321a222cd734eae68b5